### PR TITLE
reframe {callr} scope

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sandpaper
 Title: Create and Curate Carpentries Lessons
-Version: 0.0.0.9002
+Version: 0.0.0.9003
 Authors@R: 
     person(given = "Zhian N.",
            family = "Kamvar",
@@ -11,7 +11,7 @@ Description: Boilerplate directory structure, build tools, and hosting tools for
 License: MIT + file LICENSE
 Imports: 
     pkgdown (>= 1.6.0),
-    pegboard (>= 0.0.0.9006),
+    pegboard (>= 0.0.0.9007),
     commonmark,
     xml2,
     fs,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# sandpaper 0.0.0.9003
+
+* A regression in `build_markdown()` due to being called in a separate process
+  was fixed.
+* Internal functions for setting {knitr} options were migrated to live inside
+  `build_markdown()`
+
 # sandpaper 0.0.0.9002
 
 * Migrate template to use fenced divs instead of {dovetail}. 

--- a/R/build_markdown.R
+++ b/R/build_markdown.R
@@ -57,9 +57,6 @@ build_markdown <- function(path = ".", rebuild = FALSE, quiet = FALSE) {
   }
 
   # Render the episode files to the built directory ----------------------------
-  # ochunk <- knitr::opts_chunk$get()
-  # on.exit(knitr::opts_chunk$restore(ochunk), add = TRUE)
-  # set_knitr_opts()
 
   for (i in seq_len(nrow(to_be_built))) {
     build_single_episode(to_be_built$episode[i], to_be_built$hash[i], quiet = quiet)

--- a/R/utils.R
+++ b/R/utils.R
@@ -33,21 +33,6 @@ reset_git_user <- function(path) {
   }
 }
 
-set_knitr_opts <- function() {
-  knitr::opts_chunk$set(
-    comment = "",
-    fig.align = "center",
-    class.output = "output",
-    class.error = "error",
-    class.warning = "warning",
-    class.message = "output"
-  )
-}
-
-set_fig_path <- function(slug) {
-  knitr::opts_chunk$set(fig.path = file.path("fig", paste0(slug, "-")))
-}
-
 create_lesson_readme <- function(name, path) {
 
   writeLines(glue::glue("# {name}

--- a/tests/testthat/_snaps/set_schedule.md
+++ b/tests/testthat/_snaps/set_schedule.md
@@ -1,0 +1,14 @@
+# set_schedule() will display the modifications if write is not specified
+
+    carpentry: cp
+    title: Lesson Title
+    life_cycle: pre-alpha
+    license: CC-BY 4.0
+    source: https://github.com/carpentries/sandpaper
+    branch: main
+    contact: team@carpentries.org
+    
+    schedule:
+    - 01-introduction.Rmd
+    x 02-new.Rmd
+

--- a/tests/testthat/helper-hash.R
+++ b/tests/testthat/helper-hash.R
@@ -1,3 +1,7 @@
+# utility for checking if a file has the expected hash
+#
+# @param path the path to the lesson
+# @param file the path to the episode to be hashed (in the episodes dir)
 expect_hashed <- function(path, file) {
   expected_hash <- tools::md5sum(fs::path(path_episodes(path), file))
   md <- fs::path_ext_set(file, "md")

--- a/tests/testthat/test-build_markdown.R
+++ b/tests/testthat/test-build_markdown.R
@@ -14,7 +14,7 @@ test_that("markdown sources can be built without fail", {
 
   # It's noisy at first
   suppressMessages({
-  expect_output(build_lesson(res, preview = FALSE, quiet = FALSE), "ordinary text without R code")
+  expect_output(build_markdown(res, quiet = FALSE), "ordinary text without R code")
   })
 
   # see helper-hash.R
@@ -22,6 +22,15 @@ test_that("markdown sources can be built without fail", {
   h2 <- expect_hashed(res, "02-second-episode.Rmd")
   expect_equal(h1, h2, ignore_attr = TRUE)
 
+  # Output is not commented
+  built  <- get_built_files(res)
+  ep     <- trimws(readLines(built[[1]]))
+  ep     <- ep[ep != ""]
+  outid  <- grep("[1]", ep, fixed = TRUE)
+  output <- ep[outid[1]]
+  fence  <- ep[outid[1] - 1]
+  expect_match(output, "^\\[1\\]")
+  expect_match(fence, "^[`]{3}[{]\\.output[}]")
 
   # But will not built if things are not changed
   expect_silent(build_markdown(res))

--- a/tests/testthat/test-set_schedule.R
+++ b/tests/testthat/test-set_schedule.R
@@ -37,6 +37,27 @@ test_that("get_schedule() returns episodes in dir if schedule is not set", {
 
 })
 
+test_that("set_schedule() will display the modifications if write is not specified", {
+
+  clear_schedule(tmp)
+  expect_warning(s <- get_schedule(tmp), "set_schedule")
+  expect_equal(s, c("01-introduction.Rmd", "02-new.Rmd"))
+  set_schedule(tmp, s, write = TRUE)
+  expect_equal(get_schedule(tmp), s)
+  expect_snapshot_output(set_schedule(tmp, s[1]))
+  expect_equal(get_schedule(tmp), s)
+  set_schedule(tmp, s[1], write = TRUE)
+  expect_equal(get_schedule(tmp), s[1])
+
+})
+
+test_that("set_schedule() will error if no proposal is defined", {
+
+  expect_error(set_schedule(tmp), "schedule must have an order")
+
+})
+
+
 test_that("adding episodes will concatenate the schedule", {
 
   expect_equal(get_schedule(tmp), "01-introduction.Rmd")


### PR DESCRIPTION

 - {knitr} option setting is moved to inside {callr}
 - each episode sets options individually
 - regression tests added
 - tests for schedule display added

this will fix #3 